### PR TITLE
Fix 'Farenheight' typo

### DIFF
--- a/src/UI.rs
+++ b/src/UI.rs
@@ -114,11 +114,11 @@ pub fn ui(f: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .style(Style::default())
         .title(" CPU Temperature 🔥 ");
-    
+
     // Match units to decide what to display the digital thing in
     let unit = match app.units {
         Units::Celcius => "C",
-        Units::Farenheight => "F",
+        Units::Fahrenheit => "F",
     };
 
     let temp = Paragraph::new(Text::styled(

--- a/src/UI.rs
+++ b/src/UI.rs
@@ -143,7 +143,7 @@ pub fn ui(f: &mut Frame, app: &App) {
         )
         .y_axis(
             Axis::default()
-                .title("Temp (C)")
+                .title(format!("Temp ({unit})"))
                 .style(Style::default())
                 .bounds([0.0, 120.0])
                 .labels(

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use systemstat::{saturating_sub_bytes, Platform, System};
 
 pub enum Units {
     Celcius,
-    Farenheight,
+    Fahrenheit,
 }
 
 pub enum GraphType {
@@ -71,7 +71,6 @@ impl Poller {
             // set battery temp
             match sys.battery_life() {
                 Ok(battery) => {
-
                     let h = (battery.remaining_time.as_secs() / 3600) as u32;
                     let m = (battery.remaining_time.as_secs() % 60) as u32;
                     loads.battery = Some((battery.remaining_capacity * 100.0) as u8);
@@ -176,7 +175,7 @@ impl App {
     pub fn get_temp(&self) -> f32 {
         match self.units {
             Units::Celcius => self.load.temp.unwrap_or(9999.9999),
-            Units::Farenheight => self.load.temp.unwrap_or(9999.9999) * (9.0 / 5.0) + 32.0,
+            Units::Fahrenheit => self.load.temp.unwrap_or(9999.9999) * (9.0 / 5.0) + 32.0,
         }
     }
 
@@ -236,7 +235,6 @@ impl App {
             //pull load off channel
             Some(rx) => {
                 if let Ok(loads) = rx.recv_timeout(Duration::from_millis(250)) {
-
                     // Temp Vector for chart. Going to limit data points to 10k so we dont just eat memory
                     if self.temp_vec.len() > 10000 {
                         self.temp_vec = Vec::new();
@@ -245,7 +243,7 @@ impl App {
                     self.temp_vec
                         .push((self.temp_vec.len() as f64, loads.temp.unwrap_or(0.0) as f64));
 
-                    // Replace Loads struct 
+                    // Replace Loads struct
                     self.load = loads;
                 }
             }
@@ -271,8 +269,8 @@ impl App {
                                     got_message = false;
                                 }
                                 KeyActions::ToggleUnits => match self.units {
-                                    Units::Celcius => self.units = Units::Farenheight,
-                                    Units::Farenheight => self.units = Units::Celcius,
+                                    Units::Celcius => self.units = Units::Fahrenheit,
+                                    Units::Fahrenheit => self.units = Units::Celcius,
                                 },
                                 KeyActions::ClearTemp => {
                                     self.temp_vec = Vec::new();


### PR DESCRIPTION
Hi. I saw your post on reddit and comment about also being new to Rust. So I was looking at the code and found a small typo. In the temperature units, you wrote `Farenheight` instead of [`Fahrenheit`](https://en.wikipedia.org/wiki/Fahrenheit).


I ran a `rg -i "Farenheight" .`, which gave the results:
```bash
./src/UI.rs
121:        Units::Farenheight => "F",

./src/app.rs
14:    Farenheight,
179:            Units::Farenheight => self.load.temp.unwrap_or(9999.9999) * (9.0 / 5.0) + 32.0,
274:                                    Units::Celcius => self.units = Units::Farenheight,
275:                                    Units::Farenheight => self.units = Units::Celcius,
```

Listing 5 occurrences of the word.  
I fixed the typos and ran `cargo run --release` - since there is no tests - and it ran as expected.

I also noticed that when pressing `TAB` the y_axis unit didn't change, so I also fixed that. I should mention that there is an issue with the y_axis bounds when dealing with F temps (they don't change).:
![C temps](https://i.imgur.com/9qU6TDP.png)  
![!F temps](https://i.imgur.com/TgyHoOo.png)

Last, but not least, any whitespace removed was caused by `cargo fmt` which runs as soon as Vim save the file.